### PR TITLE
feat: add a Source Type to the Spells Page

### DIFF
--- a/src/components/lists/SpellList/changeColumns.tsx
+++ b/src/components/lists/SpellList/changeColumns.tsx
@@ -18,7 +18,19 @@ const useChangeColumnTable = () => {
               emptyMsg="there is no collateral related"
             />
           ),
-          width: '24%',
+          width: '15%',
+          grow: 0,
+        },
+        {
+          name: 'Source Type',
+          cell: ({ sourceType }: Definitions.SpellChange) => (
+            <LabelCell
+              emptyColor="#9a9a9a"
+              label={sourceType}
+              emptyMsg="there is no parameter"
+                  />
+              ),
+          width: '20%',
           grow: 0,
         },
         {
@@ -30,7 +42,7 @@ const useChangeColumnTable = () => {
               emptyMsg="there are no param or terms"
             />
           ),
-          width: '41.5%',
+          width: '35%',
           grow: 0,
         },
         {
@@ -45,7 +57,7 @@ const useChangeColumnTable = () => {
               emptyMsg="no previous value"
             />
           ),
-          width: '15.8%',
+          width: '15%',
           grow: 0,
         },
         {
@@ -57,7 +69,7 @@ const useChangeColumnTable = () => {
               : 'no new value';
             return <LabelCell label={newValueFormatted} emptyMsg={emptyMsg} />;
           },
-          width: '19%',
+          width: '15%',
           grow: 0,
         },
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/services/utils/transformSpellChanges.ts
+++ b/src/services/utils/transformSpellChanges.ts
@@ -22,6 +22,7 @@ const transformSpellChanges = (
       newValueFormatted: transformValues(param, Number(ele.to_value)),
       asset: ele.ilk,
       value: '',
+      sourceType: ele.source_type || '',
     };
   });
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -49,7 +49,7 @@ declare namespace Definitions {
   export type Flip = {
     id: string;
     asset: string;
-    beg: strirng;
+    beg: string;
     ttl: string;
     tau: string;
   };
@@ -63,7 +63,8 @@ declare namespace Definitions {
     title: string | null;
     tx_hash: string;
     to_value: string;
-   };
+    source_type?: string;
+  };
 
   export type SpellChange = {
     id: string;
@@ -73,6 +74,7 @@ declare namespace Definitions {
     newValueFormatted?: string;
     value: string;
     asset?: string;
+    sourceType?: string;
   };
   export type Status = 'Hat' | 'Passed' | 'Pending' | 'Skipped' | 'Expired';
   export type Spell = {


### PR DESCRIPTION
* The new "Source Type" column has been added to the table between the Collateral and Parameter columns and the correct information has been displayed.
[Add a Source Type to the Spells Page](https://trello.com/c/UAwA5xcJ/145-add-a-source-type-to-the-spells-page)