### PR TITLE
replacing experimental path for endpoint

### DIFF
--- a/src/services/loadData/spells/useLoadSpells.ts
+++ b/src/services/loadData/spells/useLoadSpells.ts
@@ -72,7 +72,7 @@ const getSpells = async (prop: { pageParam?: string; queryKey: any[] }) => {
   }
 
   const response = await apiClient.get(
-    `https://data-api.makerdao.network/v1/experimental/spells_summary?${params.toString()}&order=desc`,
+    `https://data-api.makerdao.network/v1/governance/spells_summary?${params.toString()}&order=desc`,
     {
       headers: {
         Accept: '*',


### PR DESCRIPTION
We are deprecating the experimental section of our endpoints. Most of them are being moved to their proper/final namespace.