### PR TITLE
update action version

### DIFF
--- a/.github/workflows/deploy_production.yaml
+++ b/.github/workflows/deploy_production.yaml
@@ -10,7 +10,7 @@ jobs:
         node-version: [v16.x]
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
       - name: Make envfile
         uses: SpicyPizza/create-envfile@v1.3
         with:

--- a/.github/workflows/deploy_staging.yaml
+++ b/.github/workflows/deploy_staging.yaml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
       - name: Make envfile
         uses: SpicyPizza/create-envfile@v1.3
         with:


### PR DESCRIPTION
We'll need to update the GitHub actions that rely on node12 since it's deprecated now. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

cc @eskp @sanbotto @OleksandrUA @cristidas @jeannettemcd @zdumitru